### PR TITLE
fixed Revolution IRC link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,7 +245,7 @@ Get an IRC client
 
 - Web: [Kiwiirc](https://kiwiirc.com) (easy)
 - Desktop: [Hexchat](https://hexchat.github.io)
-- Android: [Revolution IRC](https://hexchat.github.io)
+- Android: [Revolution IRC](https://github.com/MCMrARM/revolution-irc)
 
 configure
 


### PR DESCRIPTION
# brief description of changes
Fixed the URL for Revolution IRC in the Quickstart section of README.md which was a duplicate of the Hexchat URL. This is my first attempted contribution to the open source universe!