### PR TITLE
Fixed plugin import error

### DIFF
--- a/honeybot/hbotapi/main.py
+++ b/honeybot/hbotapi/main.py
@@ -143,10 +143,10 @@ class Bot_core(object):
             print("loading plugin:", file)
             try:
                 module = importlib.import_module("plugins.{}".format(file))
+                obj = module
+                self.plugins.append(obj)
             except ModuleNotFoundError as e:
                 logger.warning(f"{file}: module import error, skipped' {e}")
-            obj = module
-            self.plugins.append(obj)
 
         logger.info("Loaded plugins...")
 


### PR DESCRIPTION
…a double plugin in plugins list or raise an exception when appending local variable 'module' because it was referenced before assignment after try exception was raised.

# brief description of changes

Pull request for fixing an exception when importing an unkown plugin before a known plugin.
