### PR TITLE
Fix Issue #81:  Docstring to info.py - calc

### DIFF
--- a/honeybot/plugins/downloaded/calc/info.py
+++ b/honeybot/plugins/downloaded/calc/info.py
@@ -1,5 +1,5 @@
 
-NAME = 'abbreviation.py'
+NAME = 'calc.py'
 ORIGINAL_AUTHORS = [
     'Abdur-Rahmaan Janhangeer, pythonmembers.club'
 ]

--- a/honeybot/plugins/downloaded/calc/info.py
+++ b/honeybot/plugins/downloaded/calc/info.py
@@ -1,0 +1,16 @@
+
+NAME = 'abbreviation.py'
+ORIGINAL_AUTHORS = [
+    'Abdur-Rahmaan Janhangeer, pythonmembers.club'
+]
+
+ABOUT = '''
+evaluates maths expressions in the format supported by py
+'''
+
+COMMANDS = '''
+>>> .calc <maths expression>
+returns evaluated expression
+'''
+
+WEBSITE = ''


### PR DESCRIPTION
## Description
Added the ```info.py``` to the calc folder aimed at turning the docstring in ```main.py``` into the file itself.

Fixes Issue #81 

