### PR TITLE
Change: Move CI/CD tools configurations to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,3 +4,30 @@ requires = [
     "wheel"
 ]
 build-backend = "setuptools.build_meta"
+
+[tool.isort]
+profile = "black"
+extend_skip = [".github", ".idea", "__pycache__", "gui_manager.py", "test_core.py", "test_legacy_core.py", "test_plugin_script.py"]
+line_length = 100
+
+[tool.black]
+line-length = 100
+target-version = ['py37', 'py38', 'py39', 'py310']
+include = 'src/honeybot/plugins/downloaded/'
+exclude = '\.txt?'
+# 'extend-exclude' excludes files or directories in addition to the defaults
+extend-exclude = '''
+(
+  \.git
+  |\.github
+  |\.idea
+  |__pycache__
+  |venv
+  |gui_manager\.py,test_core\.py,test_legacy_core\.py,test_plugin_script\.py
+  |src/honeybot\/plugins\/downloaded\/calc\/main\.py
+)
+'''
+
+[tool.bandit]
+exclude = [".git", ".github", ".idea", "__pycache__", "venv", "workshop", "./build/lib/honeybot/plugins/downloaded/calc/main.py", "./build/lib/honeybot/plugins/downloaded/monopoly/main.py"]
+targets = ["./src/honeybot/plugins/downloaded"]

--- a/src/honeybot/plugins/downloaded/calc/main.py
+++ b/src/honeybot/plugins/downloaded/calc/main.py
@@ -60,7 +60,7 @@ class Plugin:
                         expr = msgs[1]
                         methods["send"](
                             info["address"],
-                            "{}".format(eval(expr, {"__builtins__": None}, safe_dict)),
+                            "{}".format(eval(expr, {"__builtins__": None}, safe_dict)),  # nosec eval_used
                         )
         except Exception as ex:
             print("woops plugin", __file__, ex)

--- a/src/honeybot/plugins/downloaded/monopoly/main.py
+++ b/src/honeybot/plugins/downloaded/monopoly/main.py
@@ -304,7 +304,7 @@ class Plugin:
             print(num_util)
             calc_string = asset.rents[num_util] + " " + str(move_amount)
             print(calc_string)
-            return eval(
+            return eval(  # nosec eval_used
                 calc_string,
                 {"__builtins__": None},
                 {"str": str, "int": int, "float": float},


### PR DESCRIPTION
Move CI/CD tools configurations to pyproject.toml with some plugins adaptations in:
- calc
- monopoly

## Description

## How Has This Been Tested?

## Additional context

Add any other context or screenshots about the pull request here.

## Checklist

- [x] I have read, understood and followed our [Contributing Guide](https://github.com/pyhoneybot/honeybot/blob/master/CONTRIBUTING.md)
- [x] My code follows the code style of this project
- [x] I have updated the documentation accordingly
- [x] I added my country flag to the `README.md`

## Code of Conduct

By submitting this issue, you agree to follow our [Code of Conduct](https://github.com/pyhoneybot/honeybot/blob/master/CODE_OF_CONDUCT.md)

- [x] I agree to follow this project's Code of Conduct
